### PR TITLE
Fix pool vertex edges iterator.

### DIFF
--- a/src/main/java/org/mastodon/graph/ref/AllEdges.java
+++ b/src/main/java/org/mastodon/graph/ref/AllEdges.java
@@ -1,6 +1,7 @@
 package org.mastodon.graph.ref;
 
 import java.util.Iterator;
+import java.util.NoSuchElementException;
 
 import org.mastodon.graph.Edges;
 
@@ -146,6 +147,9 @@ public class AllEdges< E extends AbstractEdge< E, ?, ? > > implements Edges< E >
 		@Override
 		public E next()
 		{
+			if ( edgeIndex < 0 )
+				throw new NoSuchElementException();
+
 			edgePool.getObject( edgeIndex, edge );
 			if ( in )
 			{

--- a/src/main/java/org/mastodon/graph/ref/IncomingEdges.java
+++ b/src/main/java/org/mastodon/graph/ref/IncomingEdges.java
@@ -1,6 +1,7 @@
 package org.mastodon.graph.ref;
 
 import java.util.Iterator;
+import java.util.NoSuchElementException;
 
 import org.mastodon.graph.Edges;
 
@@ -109,6 +110,9 @@ public class IncomingEdges< E extends AbstractEdge< E, ?, ? > > implements Edges
 		@Override
 		public E next()
 		{
+			if ( edgeIndex < 0 )
+				throw new NoSuchElementException();
+
 			edgePool.getObject( edgeIndex, edge );
 			edgeIndex = edge.getNextTargetEdgeIndex();
 			return edge;

--- a/src/main/java/org/mastodon/graph/ref/OutgoingEdges.java
+++ b/src/main/java/org/mastodon/graph/ref/OutgoingEdges.java
@@ -1,6 +1,7 @@
 package org.mastodon.graph.ref;
 
 import java.util.Iterator;
+import java.util.NoSuchElementException;
 
 import org.mastodon.graph.Edges;
 
@@ -109,6 +110,9 @@ public class OutgoingEdges< E extends AbstractEdge< E, ?, ? > > implements Edges
 		@Override
 		public E next()
 		{
+			if ( edgeIndex < 0 )
+				throw new NoSuchElementException();
+
 			edgePool.getObject( edgeIndex, edge );
 			edgeIndex = edge.getNextSourceEdgeIndex();
 			return edge;

--- a/src/test/java/org/mastodon/graph/EdgeCollectionsTest.java
+++ b/src/test/java/org/mastodon/graph/EdgeCollectionsTest.java
@@ -1,0 +1,134 @@
+package org.mastodon.graph;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import java.util.Iterator;
+import java.util.NoSuchElementException;
+
+import org.junit.Test;
+import org.mastodon.graph.ref.AllEdges;
+import org.mastodon.graph.ref.IncomingEdges;
+import org.mastodon.graph.ref.OutgoingEdges;
+
+public class EdgeCollectionsTest
+{
+
+	@Test( expected = NoSuchElementException.class )
+	public void testOugoingEdges()
+	{
+		final TestGraph graph = new TestGraph();
+		final TestVertex ref0 = graph.vertexRef();
+		final TestVertex ref1 = graph.vertexRef();
+		final TestEdge edgeRef = graph.edgeRef();
+
+		final int nTargets = 10;
+
+		final TestVertex v0 = graph.addVertex( ref0 ).init( 0 );
+		for ( int i = 0; i < nTargets; i++ )
+		{
+			final TestVertex vi = graph.addVertex( ref1 ).init( i + 1 );
+			graph.addEdge( v0, vi, edgeRef );
+		}
+
+		final OutgoingEdges< TestEdge > edges = v0.outgoingEdges();
+		assertEquals( "Outgoing edges do not have the expected size.", nTargets, edges.size() );
+
+		// Remove them all.
+		for ( final TestEdge edge : edges )
+			graph.remove( edge );
+
+		assertEquals( "Outgoing edges should be of size 0.", 0, edges.size() );
+		assertTrue( "Outgoing edges should be empty.", edges.isEmpty() );
+
+		final Iterator< TestEdge > it = edges.iterator();
+		assertFalse( "Edges iterator should not have a next element.", it.hasNext() );
+
+		// Should trigger NoSuchElementException.
+		it.next();
+
+		graph.releaseRef( ref0 );
+		graph.releaseRef( ref1 );
+		graph.releaseRef( edgeRef );
+	}
+
+	@Test( expected = NoSuchElementException.class )
+	public void testIncomingEdges()
+	{
+		final TestGraph graph = new TestGraph();
+		final TestVertex ref0 = graph.vertexRef();
+		final TestVertex ref1 = graph.vertexRef();
+		final TestEdge edgeRef = graph.edgeRef();
+
+		final int nTargets = 10;
+
+		final TestVertex v0 = graph.addVertex( ref0 ).init( 0 );
+		for ( int i = 0; i < nTargets; i++ )
+		{
+			final TestVertex vi = graph.addVertex( ref1 ).init( i + 1 );
+			graph.addEdge( vi, v0, edgeRef );
+		}
+
+		final IncomingEdges< TestEdge > edges = v0.incomingEdges();
+		assertEquals( "Incoming edges do not have the expected size.", nTargets, edges.size() );
+
+		// Remove them all.
+		for ( final TestEdge edge : edges )
+			graph.remove( edge );
+
+		assertEquals( "Incoming edges should be of size 0.", 0, edges.size() );
+		assertTrue( "Incoming edges should be empty.", edges.isEmpty() );
+
+		final Iterator< TestEdge > it = edges.iterator();
+		assertFalse( "Edges iterator should not have a next element.", it.hasNext() );
+
+		// Should trigger NoSuchElementException.
+		it.next();
+
+		graph.releaseRef( ref0 );
+		graph.releaseRef( ref1 );
+		graph.releaseRef( edgeRef );
+	}
+
+	@Test( expected = NoSuchElementException.class )
+	public void testEdges()
+	{
+		final TestGraph graph = new TestGraph();
+		final TestVertex ref0 = graph.vertexRef();
+		final TestVertex ref1 = graph.vertexRef();
+		final TestEdge edgeRef = graph.edgeRef();
+
+		final int nTargets = 10;
+
+		final TestVertex v0 = graph.addVertex( ref0 ).init( 0 );
+		for ( int i = 0; i < nTargets; i++ )
+		{
+			final TestVertex vi = graph.addVertex( ref1 ).init( i + 1 );
+			graph.addEdge( vi, v0, edgeRef );
+			final TestVertex vo = graph.addVertex( ref1 ).init( nTargets + i + 1 );
+			graph.addEdge( v0, vo, edgeRef );
+		}
+
+		final AllEdges< TestEdge > edges = v0.edges();
+		assertEquals( "Edges do not have the expected size.", 2 * nTargets, edges.size() );
+
+		// Remove them all.
+		for ( final TestEdge edge : edges )
+			graph.remove( edge );
+
+		assertEquals( "Edges should be of size 0.", 0, edges.size() );
+		assertTrue( "Edges should be empty.", edges.isEmpty() );
+
+		final Iterator< TestEdge > it = edges.iterator();
+		assertFalse( "Edges iterator should not have a next element.", it.hasNext() );
+
+		// Should trigger NoSuchElementException.
+		it.next();
+
+		graph.releaseRef( ref0 );
+		graph.releaseRef( ref1 );
+		graph.releaseRef( edgeRef );
+	}
+
+}

--- a/src/test/java/org/mastodon/graph/EdgeCollectionsTest.java
+++ b/src/test/java/org/mastodon/graph/EdgeCollectionsTest.java
@@ -4,6 +4,7 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 
+import java.util.Collections;
 import java.util.Iterator;
 import java.util.NoSuchElementException;
 
@@ -131,4 +132,10 @@ public class EdgeCollectionsTest
 		graph.releaseRef( edgeRef );
 	}
 
+	@Test( expected = NoSuchElementException.class )
+	public void testNormalIterator()
+	{
+		final Iterator< Object > it = Collections.emptyList().iterator();
+		it.next();
+	}
 }


### PR DESCRIPTION
Fix minor bug: 

After all edges have been removed from a vertex, the edge collection (incoming, outgoing or allEdges) have all the proper size, but the iterator behaves weirdly. It indeed correctly reports `hasNext=false`, but when prompted for `next()`, it returns a non-null edge instance which is incorrectly instantiated.
The iterator contract states that we should throw a NoSuchElement exception.

Here we add a test to the `next()` iterator method and throw this exception when adequate.
Merging this is a matter of trusting consumers to always call `hasNext()` before `next()` or not.